### PR TITLE
Improve developer experience, use neutrinorc as source-of-truth

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ module.exports = (neutrino, options = {}) => {
   const lintingEnabled = options.airbnb !== false || !neutrino.options.args.noLint;
   const airbnbOptions = merge({
     eslint: {
+      fix: true,
+      emitWarning: process.env.NODE_ENV === 'development' ||
+        neutrino.options.command === 'styleguide:start',
       baseConfig: {
         extends: ['eslint-config-prettier']
       },
@@ -35,12 +38,16 @@ module.exports = (neutrino, options = {}) => {
         'no-return-assign': 'off',
         'no-shadow': 'off',
         'no-unused-expressions': 'off',
-        'prettier/prettier': ['error', {
-          singleQuote: true,
-          bracketSpacing: true,
-          jsxBracketSameLine: true,
-          trailingComma: 'es5',
-        }],
+        'prettier/prettier': [
+          'error',
+          {
+            singleQuote: true,
+            bracketSpacing: true,
+            jsxBracketSameLine: true,
+            trailingComma: 'es5',
+          },
+          { usePrettierrc: false }
+        ],
         'padding-line-between-statements': [
           'error',
           { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
@@ -61,13 +68,23 @@ module.exports = (neutrino, options = {}) => {
       eslint: {
         rules: {
           // great idea but it's not smart enough to detect ids in all cases.
-          'jsx-a11y/label-has-for': 'off',
+          // Enable anchors with react-router Link
+          'jsx-a11y/anchor-is-valid': ['error', {
+            components: ['Link'],
+            specialLink: ['to'],
+          }],
           'jsx-a11y/click-events-have-key-events': 'off',
+          'jsx-a11y/label-has-for': 'off',
           'jsx-a11y/no-noninteractive-element-interactions': 'off',
           'jsx-a11y/no-static-element-interactions': 'off',
+          'no-console': process.env.NODE_ENV === 'development' ? 'off' : 'error',
           // handled by prettier rules
           'react/default-props-match-prop-types': 'off',
           'react/jsx-closing-bracket-location': 'off',
+          'react/jsx-handler-names': ['error', {
+            eventHandlerPrefix: 'handle',
+            eventHandlerPropPrefix: 'on',
+          }],
           'react/jsx-indent': 'off',
           // styling choice which makes using redux in es6 style more difficult.
           'react/no-multi-comp': 'off',
@@ -78,7 +95,13 @@ module.exports = (neutrino, options = {}) => {
         }
       }
     }));
-    neutrino.use(react, options.react);
+    neutrino.use(react, merge({
+      style: {
+        extract: neutrino.options.command.includes('styleguide')
+          ? false :
+          {},
+      },
+    }, options.react));
   }
 
   // Decorators generally need to be enabled *before* other

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "deepmerge": "^2.0.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-flowtype": "^2.41.0",
-    "eslint-plugin-prettier": "^2.4.0",
+    "eslint-plugin-prettier": "^2.6.0",
     "flow-bin": "^0.63.1",
     "fork-ts-checker-webpack-plugin": "^0.3.0",
     "prettier": "^1.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3005,9 +3005,9 @@ eslint-plugin-jsx-a11y@^6.0.2:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
-eslint-plugin-prettier@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz#39a91dd7528eaf19cd42c0ee3f2c1f684606a05f"
+eslint-plugin-prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
   dependencies:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"


### PR DESCRIPTION
- [x] Automatically fix _fixable_ linting errors by default 
- [x] Switching all linting errors to warnings during development to let builds continue
- [x] Update eslint-plugin-prettier to shut off using prettierrc as source of configuration. Forces neutrinorc as single source of truth
- [x] Enable react-router `Link`s as valid anchors with a11y
- [x] Don't enable extraction when coupled with styleguides
- [x] Don't mark `console.log`s as errors during development in React
- [x] Enforce event prop pattern of `on/handle` in React